### PR TITLE
ETags

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 * [Error handling](#error-handling)
 * [Versions](#versions)
 * [Record limits](#record-limits)
+* [ETags](#etags)
 * [Request & Response Examples](#request-response-examples)
 * [Mock Responses](#mock-responses)
 * [JSONP](#jsonp)
@@ -144,6 +145,27 @@ Information about record limits should also be included in the Example resonse. 
           ]
         }
     }
+    
+## ETags
+
+ETags allow clients and intermediaries to cache requests according to their unique entity id which can reduce traffic to origin servers.
+
+* Part of the metadata object.
+* Part of the HTTP Header.
+
+Documentation: http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.19
+
+Response object example:
+
+    {
+        "metadata": {
+            "etag": "xxxx-yyyy-zzzz"
+        }
+    }
+
+HTTP Header example:
+
+    etag: "xxxx-yyyy-zzzz"   
 
 ## Request & Response Examples
 


### PR DESCRIPTION
Add support for the HTTP Protocol's ETags which enable end users to cache anonymous requests and thus reduce origin load and increase client responsiveness.

Documentation on the RFC can be found here: http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.19

An implementation of ETags can be found in the GDATA API v2.0: https://developers.google.com/gdata/docs/2.0/reference#ResourceVersioning

Google is shifting their API resources around so there's a deprecated warning on this page but the section on ETags is current:
