### PR TITLE
Better contextualize the HTTP Verbs table

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ These guidelines aim to support a truly RESTful API. Here are a few exceptions:
 
 ## HTTP Verbs
 
+HTTP verbs, or methods, should be used in compliance with their definitions under the [HTTP/1.1](http://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html) standard.
+The action taken on the representation will be contextual to the media type being worked on and its current state. Here's an example of how HTTP verbs map to create, read, update, delete operations in a particular context:
+
 | HTTP METHOD | POST            | GET       | PUT         | DELETE |
 | ----------- | --------------- | --------- | ----------- | ------ |
 | CRUD OP     | CREATE          | READ      | UPDATE      | DELETE |


### PR DESCRIPTION
As an example, as opposed to a declarative part of the standard. Also gives context to HTTP/1.1 method definitions.
