### PR TITLE
Clarify "count" in responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-This is an edit... you can remove it.
-
 # White House Web API Standards
 
 * [Guidelines](#guidelines)


### PR DESCRIPTION
The undiscussed appearance of "count" in the "metadata" of several responses confused me. I think this pull is what was meant, isn't it?
