### PR TITLE
Fixed typo in JSON.

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Error responses should include a common HTTP status code, message for the develo
        suggestions about how to solve their problems here",
       "userMessage" : "This is a message that can be passed along to end-users, if needed.",
       "errorCode" : "444444",
-      "more info" : "http://www.example.gov/developer/path/to/help/for/444444,
+      "moreInfo" : "http://www.example.gov/developer/path/to/help/for/444444,
        http://drupal.org/node/444444",
     }
 


### PR DESCRIPTION
The example JSON in README.md is slightly out of sync with what is actually returned. Specifically, the key "more info" is actually "moreInfo".
