### PR TITLE
Fix Drupal 7 hook_services_resources URL link

### DIFF
--- a/drupal/README.md
+++ b/drupal/README.md
@@ -26,4 +26,4 @@ These default URL patterns necessitate a default, corresponding argument structu
 * [Posting data to a services endpoint](http://drupal.org/node/1334758)
 
 [services]: http://drupal.org/project/services
-[hsr]: http://drupalcontrib.org/api/drupal/contributions!services!services.services.api.php/function/hook_services_resources/7
+[hsr]: http://www.drupalcontrib.org/api/drupal/contributions%21services%21docs%21services.services.api.php/function/hook_services_resources/7


### PR DESCRIPTION
- Fix broken link to DrupalContrib documentation.
